### PR TITLE
feat: add NIST SP 800-63 Rev 3 Digital Identity Guidelines skill

### DIFF
--- a/plugins/nist-sp-800-63/.claude-plugin/plugin.json
+++ b/plugins/nist-sp-800-63/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "nist-sp-800-63",
+  "version": "1.0.0",
+  "description": "NIST SP 800-63 Rev 3 Digital Identity Guidelines skill for guidance on identity assurance levels, authenticator assurance levels, federation assurance levels, identity proofing, credential management, and federation protocols.",
+  "author": {
+    "name": "Simon Jackson",
+    "email": "sjackson0109@gmail.com"
+  },
+  "homepage": "https://github.com/sjackson0109/Claude-Skills-Governance-Risk-and-Compliance",
+  "repository": "https://github.com/sjackson0109/Claude-Skills-Governance-Risk-and-Compliance",
+  "license": "MIT",
+  "keywords": [
+    "nist-sp-800-63",
+    "digital-identity",
+    "identity-assurance",
+    "authenticator-assurance",
+    "federation-assurance",
+    "identity-proofing",
+    "IAL",
+    "AAL",
+    "FAL",
+    "MFA",
+    "FISMA"
+  ]
+}

--- a/plugins/nist-sp-800-63/skills/nist-sp-800-63/SKILL.md
+++ b/plugins/nist-sp-800-63/skills/nist-sp-800-63/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: nist-sp-800-63
+description: >
+  Expert NIST SP 800-63 Rev 3 Digital Identity Guidelines advisor. Use this skill
+  whenever a user asks about digital identity, identity assurance levels (IAL1, IAL2,
+  IAL3), authenticator assurance levels (AAL1, AAL2, AAL3), federation assurance levels
+  (FAL1, FAL2, FAL3), identity proofing, credential service providers (CSPs), verifiers,
+  relying parties, multi-factor authentication, phishing-resistant authenticators,
+  TOTP, FIDO2/WebAuthn, PIV, CAC, federation protocols (OIDC, SAML), identity
+  verification for online services, remote or in-person identity proofing, binding
+  of authenticators, digital identity risk assessment, selecting identity assurance
+  levels, or building an identity and access management (IAM) programme aligned to
+  NIST standards. Also trigger for questions about: "what IAL do I need?", "does MFA
+  satisfy AAL2?", "what is identity proofing?", "how do I verify a user's identity
+  remotely?", "what authenticator types are allowed at AAL2?", "what is a CSP?",
+  "how do I federate identity?", or any NIST identity, authentication, or digital
+  credential question.
+---
+
+# NIST SP 800-63 Rev 3 — Digital Identity Guidelines Skill
+
+You are an expert digital identity advisor specialising in **NIST Special Publication 800-63 Revision 3: Digital Identity Guidelines** (June 2017, with errata as of March 2020). This suite comprises four volumes: SP 800-63-3 (the overarching guideline), **SP 800-63A** (Enrollment and Identity Proofing), **SP 800-63B** (Authentication and Lifecycle Management), and **SP 800-63C** (Federation and Assertions).
+
+You assist **federal agencies, identity architects, IAM engineers, security architects, and application developers** in selecting appropriate assurance levels, implementing identity proofing, choosing and deploying authenticators, and building federation architectures.
+
+---
+
+## How to Respond
+
+| Task | Output Format |
+|------|--------------|
+| Assurance level selection | Table: Level | Requirements Met | Recommendation |
+| Identity proofing requirements | Structured list per IAL level |
+| Authenticator type guidance | Table: Type | AAL | Phishing Resistance | FIPS 140 | Notes |
+| Federation/assertion guidance | Protocol comparison or structured requirements list |
+| Risk assessment for identity | Structured risk table: xAL | Impact | Confidence | Recommended level |
+| General question | Concise prose with SP 800-63 section citations |
+
+---
+
+## SP 800-63 Rev 3 Overview
+
+### Purpose
+
+SP 800-63 Rev 3 establishes technical requirements for federal agencies implementing digital identity services. It defines three assurance dimensions and the technical requirements for each level:
+
+- **Identity Assurance Level (IAL)**: Confidence in the binding between the claimed identity and the real person
+- **Authenticator Assurance Level (AAL)**: Strength of the authentication process itself (how confident are we that the person holds the claimed authenticator)
+- **Federation Assurance Level (FAL)**: Strength of assertions passed between identity providers and relying parties in a federated system
+
+These three dimensions are **selected independently** — an application may require IAL2 but only AAL1, or IAL1 with AAL2.
+
+### Key Roles (SP 800-63-3)
+
+| Role | Definition |
+|------|-----------|
+| **Claimant** | An individual whose identity is being asserted |
+| **Credential Service Provider (CSP)** | An entity that issues credentials and manages authenticators |
+| **Verifier** | An entity that verifies the claimant's identity through a protocol |
+| **Relying Party (RP)** | An entity that uses authentication assertions to provide services |
+| **Identity Provider (IdP)** | In a federated model, the entity that manages the subscriber's identity |
+| **Subscriber** | A party that has undergone identity proofing and received credentials from the CSP |
+| **Applicant** | A party undergoing the enrolment and identity proofing process |
+
+---
+
+## Identity Assurance Levels (IAL) — SP 800-63A
+
+IAL defines the level of confidence in the claimed identity of the subscriber.
+
+### IAL1 — No Identity Proofing Required
+
+**Requirements**: No identity proofing. Self-asserted attributes accepted.
+**Use when**: The application has no need to bind a real-world identity to the digital identity (e.g., anonymous access, low-risk applications where the service can be accessed by anyone).
+**Acceptable evidence**: None required
+**Proofing method**: None
+
+### IAL2 — In-Person or Remote Proofing with Documentary Evidence
+
+**Requirements**: Identity proofing required; real-world existence of the claimed identity verified. Attributes are verified against authoritative sources or documentary evidence.
+**Use when**: The service relies on the subscriber's identity (e.g., accessing government benefits, e-signature, court filings).
+**Acceptable evidence**:
+- **Superior evidence** (1 sufficient): Passport (US or foreign with MRZ), Real ID driver's licence or state ID, military ID
+- **Strong evidence** (2 sufficient, or 1 strong + 2 fair): Driver's licence (non-Real ID), state ID, national ID card, military retiree ID, Permanent Resident Card
+- **Fair evidence** (2 required in combination): Voter registration card, utility bills (current), bank statement, government-issued document with photo
+
+**Proofing methods** (IAL2):
+1. **In-person proofing**: Present original documents to trained operator; operator verifies authenticity; biometric binding optional
+2. **Supervised remote proofing**: Live video session with a trained operator; document scan verified via automated and/or human review; biometric comparison against AAMVA/DMV records or passport chip
+
+**Biometric**: Optional at IAL2; if collected, must be used to prevent duplicate enrolment
+
+### IAL3 — In-Person Proofing with Biometric Binding
+
+**Requirements**: In-person proofing with a trained representative. Physical inspection of original documents. Biometric collection required and bound to the subscriber's identity record.
+**Use when**: The highest confidence in identity is required; national security systems; issuing physical identity credentials.
+**Acceptable evidence**: Superior evidence OR strong + biometric comparison against a government authoritative database
+**Proofing method**: In-person only; biometric capture (fingerprint, facial image) bound to the enrolment record
+
+---
+
+## Authenticator Assurance Levels (AAL) — SP 800-63B
+
+AAL defines the strength of the authentication process.
+
+### Authenticator Types and AAL Eligibility
+
+| Authenticator Type | Description | AAL1 | AAL2 | AAL3 |
+|-------------------|-------------|------|------|------|
+| Memorised Secret (Password/PIN) | Something the user knows | Yes | No (alone) | No (alone) |
+| Look-Up Secrets (backup codes) | Static codes from a printed list | Yes | No (alone) | No |
+| Out-of-Band (SMS/PSTN) | One-time code sent via SMS or voice | Yes | Restricted (see below) | No |
+| Single-Factor OTP (TOTP app) | Time-based or HMAC-based OTP | Yes | Yes (as 2nd factor) | No |
+| Multi-Factor OTP Device | Hardware OTP with PIN | Yes | Yes | No |
+| Single-Factor Cryptographic Software | Private key in software (e.g., browser key) | Yes | No (alone) | No |
+| Single-Factor Cryptographic Device | Hardware key (e.g., FIDO2 security key) | Yes | Yes (as 2nd factor) | Yes (with PIN) |
+| Multi-Factor Cryptographic Software | Software private key with memorised secret | Yes | Yes | No |
+| Multi-Factor Cryptographic Device (hardware) | PIV card, CAC, FIDO2 hardware key with PIN | Yes | Yes | Yes |
+
+**AAL1**: Single-factor authentication. Any permitted authenticator type. Memorised secrets acceptable alone.
+**AAL2**: Multi-factor authentication required. At least two of: something you know, something you have, something you are. Phishing resistance not required but recommended.
+**AAL3**: Phishing-resistant hardware-based multi-factor authentication. Cryptographic device (hardware) required. Verifier impersonation resistance required. In-person verification of hardware bond may be required.
+
+### Phishing Resistance at AAL
+
+- **AAL1**: No phishing resistance required
+- **AAL2**: Phishing resistance not required but recommended; SMS OTP is "restricted" at AAL2 (agencies must document risk)
+- **AAL3**: Verifier impersonation resistance required — only hardware cryptographic authenticators that bind to the specific verifier (e.g., FIDO2 with origin binding, PIV with card-validated TLS) satisfy this requirement
+
+### SMS/PSTN at AAL2 — "Restricted" Status
+
+SP 800-63B designates SMS and PSTN-based out-of-band authenticators as "RESTRICTED" at AAL2. Agencies using them must:
+1. Document the risk assessment justifying the use
+2. Offer subscribers at least one alternative AAL2-eligible authenticator
+3. Implement additional risk controls (fraud detection, anomaly detection)
+4. Notify subscribers of risk
+
+### FIPS 140 Requirements
+
+| AAL | FIPS 140 Requirement |
+|-----|---------------------|
+| AAL1 | No FIPS 140 required |
+| AAL2 | If cryptographic authenticator used: FIPS 140 Level 1 overall (Level 2 physical security for hardware authenticators) |
+| AAL3 | FIPS 140 Level 2 overall; Level 3 physical security |
+
+### Reauthentication Requirements
+
+| AAL | Inactivity Timeout | Absolute Session Limit |
+|-----|-------------------|----------------------|
+| AAL1 | 30 days | No absolute limit |
+| AAL2 | 30 minutes inactivity OR 12 hours absolute | 12 hours (with reauthentication) |
+| AAL3 | 15 minutes inactivity OR 12 hours absolute | 12 hours |
+
+---
+
+## Federation Assurance Levels (FAL) — SP 800-63C
+
+FAL describes the strength of an assertion passed from an IdP to an RP in a federated authentication scenario.
+
+### FAL1 — Bearer Assertion from IdP
+
+**Requirements**: Bearer assertion from the IdP; assertion must be signed (e.g., with RS256) so the RP can verify it was issued by the IdP; assertion delivered through the front channel (browser redirect) or back channel
+**Protocols**: OpenID Connect (OIDC) ID tokens via implicit or authorization code flow; SAML 2.0 basic
+
+### FAL2 — Bearer Assertion Encrypted for RP
+
+**Requirements**: Assertion must be encrypted for the specific RP so that only the RP can decrypt it; prevents honest-but-curious IdP from observing what the RP is doing with the assertion
+**Protocols**: OIDC with token endpoint using RS256 signing + RSA-OAEP encryption for ID token; SAML with XML Encryption
+
+### FAL3 — Holder-of-Key Assertion
+
+**Requirements**: Assertion must be cryptographically bound to the subscriber's authenticator so that only a holder of the matching key can use the assertion; provides protection against assertion theft
+**Protocols**: token binding or equivalent mechanisms; FIDO2 with attestation; SAML HoK profile
+
+### Selecting FAL
+
+| FAL | When to Use |
+|-----|------------|
+| FAL1 | Low-risk federated applications; internal enterprise applications; where assertion interception risk is low |
+| FAL2 | Moderate-risk applications where assertion confidentiality is important; where the IdP should not know what the RP is doing with the assertion |
+| FAL3 | High-risk applications; national security systems; where assertion replay or theft is a significant threat |
+
+---
+
+## Digital Identity Risk Assessment
+
+SP 800-63-3 Section 6 defines a risk assessment process for selecting the appropriate xAL levels.
+
+### Step 1 — Identify Transactions and Potential Harms
+
+For each transaction in the application, identify what could go wrong if:
+- The wrong person was authenticated (authentication failure)
+- The identity proofing was wrong (the person is not who they claim)
+- A federation assertion was compromised
+
+### Step 2 — Assess Potential Harm Categories
+
+| Harm Category | Description |
+|--------------|-------------|
+| Inconvenience, distress, or damage to standing | Embarrassment, loss of reputation |
+| Financial loss or liability | Direct financial harm to the subscriber or RP |
+| Harm to agency programs or public interests | Mission failure, regulatory violation |
+| Unauthorised release of sensitive information | Disclosure of PII, PHI, or classified material |
+| Personal safety | Physical harm to the subscriber or others |
+| Civil or criminal violations | Legal liability |
+
+### Step 3 — Determine Impact Level
+
+For each harm category, assess impact as Low, Moderate, or High.
+
+| Impact | Definition |
+|--------|-----------|
+| Low | Limited adverse effect; minor inconvenience; easily recoverable |
+| Moderate | Significant adverse effect; substantial harm to reputation, financial loss, mission degradation |
+| High | Severe or catastrophic adverse effect; major financial loss, serious mission degradation, loss of safety |
+
+### Step 4 — Select xAL Based on Maximum Impact
+
+| Maximum Impact | Minimum IAL | Minimum AAL | Minimum FAL |
+|--------------|-------------|-------------|-------------|
+| Low | IAL1 | AAL1 | FAL1 |
+| Moderate | IAL2 | AAL2 | FAL2 |
+| High | IAL3 | AAL3 | FAL3 |
+
+Agencies may select a higher xAL than the minimum if mission requirements, policy, or risk acceptance decisions warrant.
+
+---
+
+## Credential and Authenticator Lifecycle — SP 800-63B
+
+### Binding and Enrollment
+- New authenticators must be **bound to the subscriber's account** during enrolment
+- If the subscriber already has an existing authenticator, adding a new authenticator requires **re-authentication with the existing authenticator** (or identity verification at the appropriate IAL)
+- Lost authenticator: replacement requires identity proofing at or above the IAL of the original enrolment
+
+### Authenticator Requirements
+- **Memorised secrets**: Minimum 8 characters; no complexity requirements mandated (complexity rules are deprecated in 800-63B); check against breach corpora (Have I Been Pwned list); no mandatory periodic expiry; expiry required only on suspicion of compromise
+- **TOTP apps**: Algorithm: TOTP (RFC 6238) or HOTP (RFC 4226); 6-8 digit codes; valid window up to 30 seconds
+- **Hardware OTP**: Nonce-based or time-based; must be validated by the verifier within acceptable time window
+
+### Account Recovery
+At AAL2 and AAL3, account recovery must be at the same or higher assurance level as the original enrollment. Recovery codes (Look-up Secrets) may be issued at setup time.
+
+---
+
+## Core Workflows
+
+### 1. Selecting xAL Levels for an Application
+1. Identify all transactions in the application
+2. For each transaction, identify potential harms from misrepresented identity, authentication failure, or assertion compromise
+3. Assess impact level (Low / Moderate / High) for each harm category
+4. Select xAL at Minimum based on maximum impact; document rationale
+5. Review against agency policy and OMB guidance (M-19-17 for high-value assets)
+6. Document the Digital Identity Risk Assessment in the system security documentation
+
+### 2. Advising on Authenticator Selection
+1. Confirm the required AAL (from risk assessment)
+2. For AAL1: any authenticator permitted; memorised secret adequate
+3. For AAL2: two factors required; recommend hardware FIDO2 key or multi-factor OTP over SMS; flag SMS as RESTRICTED
+4. For AAL3: hardware cryptographic MFA only; FIDO2 hardware key with PIN or PIV/CAC; document FIPS 140 requirement
+
+### 3. Planning Identity Proofing
+1. Confirm the required IAL (from risk assessment)
+2. For IAL1: no proofing required; document rationale
+3. For IAL2: select in-person or supervised remote proofing; identify acceptable documentary evidence; plan biometric binding if needed
+4. For IAL3: plan in-person proofing; identify trained operators; plan biometric collection
+
+---
+
+## Reference Files
+
+- `references/assurance-levels.md` — Detailed IAL, AAL, and FAL requirements tables, selection matrices, and xAL combinations
+- `references/authenticator-requirements.md` — Per-authenticator-type requirements, FIPS 140 levels, OTP algorithm requirements, reauthentication tables, lifecycle requirements
+- `references/identity-proofing.md` — Identity proofing processes for IAL2 and IAL3 including evidence types, validation methods, biometric requirements, remote proofing requirements
+
+**When to load:**
+- Selecting assurance levels or performing a digital identity risk assessment → load `references/assurance-levels.md`
+- Choosing authenticator types or designing authentication flows → load `references/authenticator-requirements.md`
+- Planning identity proofing or CSP enrolment → load `references/identity-proofing.md`
+
+---
+
+## Disclaimer
+
+This skill is based on NIST SP 800-63 Rev 3 (June 2017) and its errata (March 2020), a freely available NIST publication. NIST SP 800-63-4 is in draft as of 2024; agencies should monitor csrc.nist.gov for the final publication and update their implementations accordingly. This skill does not constitute legal or compliance advice. Federal agencies must also comply with OMB M-19-17 (Enabling Mission Delivery through Improved Identity, Credential, and Access Management).

--- a/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/assurance-levels.md
+++ b/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/assurance-levels.md
@@ -1,0 +1,213 @@
+# Assurance Levels Reference — NIST SP 800-63 Rev 3
+
+Source: NIST SP 800-63-3 (June 2017), SP 800-63A Rev 3, SP 800-63B Rev 3, SP 800-63C Rev 3
+
+---
+
+## Identity Assurance Level (IAL) — Detailed Requirements
+
+### IAL1
+
+No identity proofing. Self-asserted attributes accepted without verification.
+
+**Risks accepted by using IAL1**:
+- The subscriber may not be who they claim to be
+- Any person can create an account
+- Attributes (name, email) are unverified
+
+**Appropriate for**:
+- Public-facing applications with no access to personal data
+- Anonymous or pseudonymous services
+- Services where the user's real identity is irrelevant to the service provided
+
+**Not appropriate for**:
+- Services that disburse benefits or funds to individuals
+- Applications with access to personal health, financial, or safety data
+- High-value asset systems
+
+---
+
+### IAL2 — Full Requirements Table
+
+| Requirement | Remote (Unsupervised) | Remote (Supervised) | In-Person |
+|------------|----------------------|---------------------|----------|
+| Identity proofing required | Yes | Yes | Yes |
+| Evidence required | 1 Superior OR 1 Strong + 2 Fair | 1 Superior OR 1 Strong + 2 Fair | 1 Superior OR 1 Strong + 2 Fair |
+| Evidence must be unexpired | Yes | Yes | Yes |
+| Evidence validation against issuer | Against available authoritative sources | Against available authoritative sources | Against available authoritative sources |
+| Address confirmation required | Yes (notice to home address on record) | Yes | Yes |
+| Biometric required | No (optional) | No (optional) | No (optional) |
+| Live operator involvement | No | Yes (via video link) | Yes (in-person) |
+| Allowed? (as of 800-63A-3 errata) | See note below | Yes | Yes |
+
+**Note on unsupervised remote proofing (IAL2)**: The original SP 800-63A permitted unattended remote proofing with strong document validation and liveness detection. Agencies must use approved KBV (knowledge-based verification) limitations — KBV alone is NOT sufficient at IAL2; it may only be used as a secondary supplement. As of the March 2020 errata, agencies should consider whether their unsupervised remote proofing implementation meets the normative requirements.
+
+**Address confirmation at IAL2**:
+If not verified in-person:
+- Send enrollment code to the address of record via postal mail
+- Enrollment code must be validated by the subscriber within 5-day validity window
+- OR, a USPS National Change of Address (NCOA) query is performed
+
+---
+
+### IAL3 — Full Requirements Table
+
+| Requirement | IAL3 |
+|------------|------|
+| Proofing type | In-person only |
+| Operator | Trained, authorised CSP representative |
+| Evidence | Superior (1) AND physical document check; or Strong evidence with biometric match against authoritative source |
+| Evidence validation | Physical authentication features checked (holograms, watermarks, MRZ validation) |
+| Biometric collection | Required; facial image and/or fingerprint |
+| Biometric binding | Biometric template bound to the identity record; used for future in-person re-verification |
+| Duplicate enrolment check | Required — biometric compared against existing records to prevent creation of multiple identities |
+| FIPS 140 for biometric capture | Level 1 minimum for the capture device |
+
+---
+
+## Authenticator Assurance Level (AAL) — Requirements Summary
+
+### AAL1 Requirements
+
+- **Factors**: Single factor
+- **Permitted types**: Any authenticator type in SP 800-63B Table 1
+- **Memorised secrets**: Minimum 8 characters; no other requirements
+- **Reauthentication**: After 30 days of inactivity
+- **FIPS 140**: Not required
+- **Phishing resistance**: Not required
+- **Verifier compromise resistance**: Not required
+- **Communications security**: Approved cryptography required for authenticator output transmission
+
+### AAL2 Requirements
+
+- **Factors**: Multi-factor (two or more)
+- **Permitted multi-factor combinations**:
+  - Multi-Factor OTP Device (hardware) + Memorised Secret
+  - Single-Factor OTP Device + Memorised Secret
+  - Multi-Factor Cryptographic Software + Memorised Secret (or inherence)
+  - Single-Factor Cryptographic Device + Memorised Secret
+  - Multi-Factor Cryptographic Device
+- **SMS/PSTN**: RESTRICTED — permitted with documented risk assessment and alternative authenticator offered
+- **Reauthentication**: 30 minutes inactivity AND 12 hours absolute (with reauthentication)
+- **FIPS 140**: Level 1 overall for cryptographic authenticators; Level 2 physical security for hardware cryptographic authenticators
+- **Phishing resistance**: Not required but recommended
+- **Verifier compromise resistance**: Not required
+- **Man-in-the-Middle resistance**: Required (secure channel)
+
+### AAL3 Requirements
+
+- **Factors**: Multi-factor hardware cryptographic
+- **Permitted types only**:
+  - Multi-Factor Cryptographic Device (hardware)
+  - Single-Factor Cryptographic Device + Memorised Secret
+- **Phishing resistance / verifier impersonation resistance**: Required — the authenticator must bind to a specific verifier (e.g., FIDO2 origin binding, TLS channel binding)
+- **Reauthentication**: 15 minutes inactivity AND 12 hours absolute
+- **FIPS 140**: Level 2 overall; Level 3 physical security
+- **Verifier compromise resistance**: Required
+- **Intent**: Authenticator must require explicit user action (e.g., pressing a button on the hardware key)
+
+---
+
+## Federation Assurance Level (FAL) — Requirements Summary
+
+### FAL1
+
+| Requirement | Value |
+|------------|-------|
+| Assertion type | Bearer |
+| Assertion signed | Yes (IdP's private key) |
+| Assertion encrypted | Not required |
+| Delivery | Front or back channel |
+| Example protocol | OIDC with RS256-signed ID token; SAML with XML-DSig |
+| Subscriber binding | Not required |
+
+### FAL2
+
+| Requirement | Value |
+|------------|-------|
+| Assertion type | Bearer |
+| Assertion signed | Yes |
+| Assertion encrypted | Yes — encrypted for the specific RP's public key |
+| Delivery | Front or back channel |
+| Example protocol | OIDC with encrypted ID token (RS256 + RSA-OAEP or A128KW); SAML with XML Encryption |
+| Subscriber binding | Not required |
+
+### FAL3
+
+| Requirement | Value |
+|------------|-------|
+| Assertion type | Holder-of-key |
+| Assertion signed | Yes |
+| Assertion encrypted | Recommended |
+| Delivery | Back channel preferred |
+| Example protocol | FIDO2 with assertion cryptographically bound to subscriber key; Token Binding; SAML HoK profile |
+| Subscriber binding | Required — assertion can only be used by the holder of the matching private key |
+
+---
+
+## xAL Selection Matrix
+
+### By Impact Level (SP 800-63-3 Table 6-2)
+
+| Impact Level | Recommended IAL | Recommended AAL | Recommended FAL |
+|-------------|----------------|----------------|----------------|
+| Low | IAL1 | AAL1 | FAL1 |
+| Moderate | IAL2 | AAL2 | FAL2 |
+| High | IAL3 | AAL3 | FAL3 |
+
+### Allowed xAL Combinations
+
+The three assurance levels are independent. Common valid combinations:
+
+| Scenario | IAL | AAL | FAL | Rationale |
+|---------|-----|-----|-----|----------|
+| Public information service | 1 | 1 | 1 | No PII, no harm from misidentification |
+| Benefits eligibility inquiry (no disbursement) | 2 | 2 | 2 | Moderate impact if wrong person accesses data |
+| Benefits disbursement | 2 | 2 | 2 | Moderate financial harm if wrong person claims |
+| Healthcare portal (PHI access) | 2 | 2 | 2 | Moderate harm from PHI disclosure |
+| High-value asset system (HVA) | 3 | 3 | 3 | Severe mission harm; OMB M-19-17 applies |
+| Internal admin app (federated SSO) | 1 | 2 | 1 | No external identity; strong auth required |
+| PIV-gated federal system | 2 or 3 | 3 | 3 | PIV satisfies IAL2/3 + AAL3 |
+
+### Notable Decoupled Combinations
+
+- **IAL1 + AAL2**: No identity proofing needed, but strong authentication required (e.g., a service that grants access by role after strong auth, but doesn't need to verify who the person is in the real world)
+- **IAL2 + AAL1**: Identity verified but single-factor auth acceptable (e.g., low-sensitivity service that still needs to know who the person is — uncommon and discouraged for most scenarios)
+
+---
+
+## OMB Supplemental Requirements (M-19-17)
+
+OMB Memorandum M-19-17 (May 2019) directed ICAM policy for federal agencies:
+
+| Requirement | When Applicable |
+|------------|----------------|
+| Identity proofing at IAL2 minimum for all government-issued digital credentials | All federal programs issuing digital credentials |
+| PIV or PIV-derived credentials for federal employee and contractor access to federal systems | Federal employees and contractors accessing High Value Assets |
+| Strong authentication (AAL2 minimum) for all federal applications | All federal agencies |
+| Phishing-resistant authentication for all high-value assets | HVAs per OMB M-19-03 |
+
+---
+
+## PIV and CAC in the 800-63B Framework
+
+The PIV card (FIPS 201) and the Common Access Card (CAC) are **Multi-Factor Cryptographic Devices** that satisfy:
+- AAL2 (contact or contactless interface with PIN)
+- AAL3 (contact interface with PIN; satisfies verifier impersonation resistance via TLS channel binding or key confirmation)
+
+PIV-Derived Credentials (PIV-D) issued to mobile devices satisfy AAL2.
+
+---
+
+## Deprecated Practices (SP 800-63B)
+
+The following practices from older NIST guidance are deprecated in SP 800-63B:
+
+| Deprecated Practice | Why Deprecated |
+|--------------------|---------------|
+| Mandatory password expiration (periodic rotation without cause) | Forces users to choose weaker predictable patterns |
+| Knowledge-Based Authentication (KBA/KBV) as sole authenticator | KBV data often publicly available; does not constitute possession factor |
+| Password complexity rules (upper/lower/number/special) | Shown to reduce entropy and increase predictable substitutions |
+| Limiting password characters (excluding special chars) | Reduces entropy |
+| Password hints | Reduces security of memorised secret |
+| Security questions for account recovery | KBV; same deprecation reasons as KBA |

--- a/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/authenticator-requirements.md
+++ b/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/authenticator-requirements.md
@@ -1,0 +1,229 @@
+# Authenticator Requirements — NIST SP 800-63B Rev 3
+
+Source: NIST SP 800-63B Rev 3 (June 2017), errata March 2020
+
+---
+
+## Authenticator Type Definitions
+
+### 1. Memorised Secret (Password or PIN)
+
+**Definition**: A secret value that is intended to be chosen and memorised by the user.
+
+**Requirements**:
+- Minimum 8 characters for user-chosen passwords
+- Minimum 6 digits for PINs used as a single factor (AAL1 only)
+- Maximum length: at least 64 characters must be supported
+- All printable ASCII characters and Unicode MUST be accepted
+- Spaces MUST be counted when calculating length (leading/trailing spaces may be trimmed for comparison)
+- Passwords SHALL be compared in a case-sensitive manner
+
+**Verifier requirements**:
+- Check against a list of commonly-used, expected, or compromised passwords (e.g., HIBP breach lists, dictionary words, context-specific words like the service name)
+- Rate limiting or lockout required after repeated failed attempts (NIST does not define exact thresholds; agencies should implement based on risk)
+- No truncation of passwords — full character set must be preserved
+- Passwords MUST be stored as salted hashes using an approved algorithm (e.g., Argon2, bcrypt, scrypt, or PBKDF2 with SHA-256 and at least 10,000 iterations)
+- Temporary passwords (for reset) must be single-use and expire after a short time period
+
+**What is deprecated (MUST NOT do)**:
+- Mandatory periodic rotation without evidence of compromise
+- Password complexity rules (mixed case + numbers + special chars combinations)
+- Password hints
+- Security questions for account recovery as sole mechanism
+- Restricting what characters can be used
+
+---
+
+### 2. Look-Up Secrets (Backup Codes)
+
+**Definition**: Physical or electronic record containing a set of secrets shared between the claimant and the CSP. Examples: printed backup codes, recovery codes.
+
+**Requirements**:
+- At least 112 bits of entropy (or at least 6 characters from a 64-character set; a common implementation is 8-10 alphanumeric characters)
+- Each look-up secret must be used only once (single-use)
+- Any remaining unused look-up secrets must be invalidated after a new set is issued
+- Must be stored hashed at the verifier
+
+**AAL eligibility**: AAL1 only (count as a single factor — possession)
+
+---
+
+### 3. Out-of-Band Authenticators (OOB) — Includes SMS, Email, Voice
+
+**Definition**: A separate communications channel (the "out-of-band" device) is used to verify possession.
+
+**Requirements (for push notifications on dedicated app)**:
+- Uniquely addressable device; authenticity of device verified at binding time
+- Push notifications require user action to approve (not just passive receipt)
+
+**SMS/PSTN requirements (RESTRICTED)**:
+Because the PSTN is not end-to-end encrypted and SIM-swapping attacks exist, SMS and PSTN-based OOB is designated RESTRICTED at AAL2. Agencies using SMS must:
+1. Document the risk in a formal risk assessment
+2. Offer subscribers at least one non-restricted alternative (e.g., TOTP app or hardware key)
+3. Monitor for evidence that SMS is not longer adequately protecting the application
+4. Issue risk notifications to subscribers
+
+**Email-based OTP**: NOT PERMITTED as an out-of-band authenticator at AAL2. Email is not a "separate channel" for identity verification purposes and is a common attack target.
+
+---
+
+### 4. Single-Factor OTP (TOTP/HOTP Application)
+
+**Definition**: A software authenticator app (Authenticator app) that generates short-term OTP codes using TOTP (RFC 6238) or HOTP (RFC 4226).
+
+**Algorithm requirements**:
+- TOTP: 30-second time step; X.509-level time synchronisation recommended; validity window: adjacent ±1 step acceptable
+- HOTP: Counter-based; must accept at a look-ahead window (SP 800-63B recommends a maximum look-ahead of 10 counter values)
+- OTP length: At least 6 digits; 8 digits preferred for increased entropy
+- Each OTP code must be single-use; verifier must store last used OTP to prevent reuse
+
+**Security**: App is locked to the device via a secret seed; seed must be securely provisioned and stored on the device
+**FIPS 140**: Not required for AAL2 software OTP apps; required at Level 1 for any software used in an AAL3 scenario
+
+---
+
+### 5. Multi-Factor OTP Device (Hardware Token)
+
+**Definition**: A hardware device that generates OTP codes, activated by a second factor (typically a PIN or biometric).
+
+**Examples**: RSA SecurID with PIN, YubiKey OTP mode with PIN
+
+**Requirements**:
+- Must require a PIN or other second activation factor to generate the OTP
+- Hardware must resist physical tampering to extract the seed
+- FIPS 140 Level 2 physical security required
+
+**AAL eligibility**: AAL2 (satisfies both factors in a single hardware device)
+
+---
+
+### 6. Single-Factor Cryptographic Software
+
+**Definition**: Private key stored in software (e.g., in a browser, in a software certificate store).
+
+**Examples**: Browser TLS client certificates (software key), software-stored FIDO2 keys
+
+**Requirements**:
+- Must use approved cryptographic algorithms (RSA-2048+, EC P-256 or higher)
+- Key must be bound to the application (origin, relying party)
+- Single-factor only — requires combination with second factor for AAL2
+
+**AAL eligibility**: AAL1 only (single factor); AAL2 as second factor combined with memorised secret
+
+---
+
+### 7. Single-Factor Cryptographic Device (Hardware Key)
+
+**Definition**: A hardware device containing a cryptographic key, activated by a simple user presence check (e.g., button press) without a PIN.
+
+**Examples**: FIDO2 hardware security key without PIN configured (activation by touch only)
+
+**Requirements**:
+- Hardware must resist extraction of private key
+- Must require an explicit user action (button press, card insert) to sign
+- FIPS 140 Level 2 physical security required
+
+**AAL eligibility**: AAL2 as second factor (combined with memorised secret)
+
+---
+
+### 8. Multi-Factor Cryptographic Software
+
+**Definition**: Private key stored in software, where activation requires a memorised secret or biometric (the second factor is software-internal).
+
+**Examples**: Software certificate protected by a PIN or passphrase; PIV-derived credential in a locked key container on a mobile device
+
+**Requirements**:
+- Activation secret (PIN/passphrase) must meet memorised secret requirements
+- Key storage protected by the OS or secure enclave
+
+**AAL eligibility**: AAL2 (satisfies both factors within one software authenticator)
+
+---
+
+### 9. Multi-Factor Cryptographic Device (Hardware Token with PIN)
+
+**Definition**: A hardware device containing a cryptographic key, activated by a PIN or biometric (second factor is presented to the hardware).
+
+**Examples**: PIV card (FIPS 201), CAC, FIDO2 security key with PIN, YubiKey in FIDO2 mode with configured PIN, smart card
+
+**Requirements**:
+- PIN or biometric is presented directly to the hardware device (not the verifier)
+- Hardware must verify the PIN/biometric before releasing the key operation
+- FIPS 140 Level 2 overall; Level 3 physical security (for AAL3)
+- Verifier impersonation resistance: FIDO2 origin binding or TLS channel binding (for AAL3)
+
+**AAL eligibility**: AAL2 and AAL3
+
+---
+
+## Authenticator Binding and Enrollment
+
+### Initial Binding
+At enrollment, the authenticator is bound to the subscriber's identity record. Requirements:
+1. Binding must occur in person, or via a secure binding ceremony using an existing, already-enrolled authenticator at the required AAL
+2. The binding link (for a one-time enrollment URL) must have a short expiry (10 minutes or less) and be single-use
+3. Binding confirmation must be sent to the subscriber's verified address
+
+### Adding Additional Authenticators
+When a subscriber with an existing authenticator wants to add another:
+1. Reauthenticate with the existing authenticator at or above the required AAL
+2. Verify identity if the new authenticator will replace the existing one (not just supplement it)
+3. Issue confirmation to the verified address
+
+### Authenticator Recovery
+If all authenticators are lost:
+- Identity reverification at the IAL of the original enrollment is required
+- Recovery codes (look-up secrets) may have been issued at enrollment time
+- KBA/KBV alone is NOT sufficient for account recovery at AAL2 or higher
+
+### Authenticator Expiry and Revocation
+- Hardware authenticators: must be revocable (CSP must be able to bind a revocation to the subscriber's account)
+- Software authenticators: revocation via account disable or explicit de-binding
+- PIV cards: revocation via the issuing agency CRL or OCSP
+
+---
+
+## Reauthentication Requirements — Full Table
+
+| AAL | Inactivity Timeout | Absolute Time Before Reauthentication | Reauthentication Method |
+|-----|------------------|--------------------------------------|------------------------|
+| AAL1 | 30 days | No absolute limit | Any permitted AAL1 method |
+| AAL2 | 30 minutes | 12 hours | Full AAL2 authentication (both factors) |
+| AAL3 | 15 minutes | 12 hours | Full AAL3 authentication (hardware + PIN/biometric) |
+
+For federated sessions:
+- The RP sets session timeouts; the IdP sets federation session lifetimes
+- RP may request fresh authentication assertions from the IdP at any time
+- Passive reauthentication (where available in the protocol) does not reset the inactivity clock
+
+---
+
+## Verifier and CSP Security Requirements
+
+### Verifier Requirements (applying to all AALs)
+- Use approved cryptographic algorithms (FIPS-approved; CNSA algorithms for national security systems)
+- Transmit authenticator output over approved-cryptography-protected channel (TLS 1.2+ required; TLS 1.3 recommended)
+- Rate limit authentication attempts; implement lockout or exponential backoff
+- Notify the subscriber of any authentication event (new device, unexpected location) via a separate channel
+- For verified attributes, protect PII per applicable privacy regulations and SP 800-63A requirements
+
+### CSP Requirements
+- Store all authenticator secrets using salted cryptographic hashes
+- Protect CSP private keys at the same FIPS 140 level as required by the AAL
+- Conduct regular audits of authenticator binding and lifecycle events
+- Operate a revocation service accessible to relying parties
+
+---
+
+## Commonly Used Authenticator Combinations by Use Case
+
+| Use Case | Recommended Authenticator(s) | AAL |
+|----------|------------------------------|-----|
+| Consumer web application (low risk) | Password | AAL1 |
+| Consumer web app (personal data access) | Password + TOTP app | AAL2 |
+| Enterprise app (moderate risk) | Password + hardware FIDO2 key (PIN) | AAL2 |
+| Federal employee access to non-HVA system | PIV card | AAL2/3 |
+| Federal employee access to HVA system | PIV card (contact interface) with TLS binding | AAL3 |
+| Mobile device access (federal employee) | PIV-D (Derived PIV) + biometric on device | AAL2 |
+| Developer API access | OAuth 2.0 token (short-lived) + client certificate | AAL2 |

--- a/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/identity-proofing.md
+++ b/plugins/nist-sp-800-63/skills/nist-sp-800-63/references/identity-proofing.md
@@ -1,0 +1,228 @@
+# Identity Proofing Reference — NIST SP 800-63A Rev 3
+
+Source: NIST SP 800-63A Revision 3 (June 2017), errata March 2020
+
+---
+
+## Identity Proofing Overview
+
+Identity proofing is the process by which a Credential Service Provider (CSP) collects and verifies information about a person to bind a real-world identity to a digital account. The strength of the proofing process determines the Identity Assurance Level (IAL).
+
+**The three phases of identity proofing (SP 800-63A Section 4.2)**:
+1. **Resolution**: Collect identifying attributes from the applicant and resolve them to a unique person
+2. **Validation**: Validate the collected evidence as genuine and accurate
+3. **Verification**: Verify that the validated identity belongs to the applicant in front of the CSP (binding)
+
+---
+
+## Evidence Types and Strength
+
+SP 800-63A classifies identity evidence into four strength levels: Superior, Strong, Fair, and Weak. Weak evidence is not permitted at IAL2 or IAL3.
+
+### Superior Evidence
+
+Evidence is designated Superior if it:
+- Is issued by a federal or state government agency
+- Contains a photograph
+- Includes a machine-readable zone (MRZ) or chip (RFID/contactless IC) with biographical and biometric data
+- Uses protective printing features that resist tampering and counterfeiting
+- Has a validity period that is currently unexpired
+
+**Examples of Superior evidence**:
+- US Passport or US Passport Card (with NFC chip)
+- Foreign passport with MRZ (ICAO 9303 compliant)
+- US Permanent Resident Card (Green Card) with RFID chip
+
+### Strong Evidence
+
+Evidence is designated Strong if it:
+- Is issued by a government agency
+- Contains a photograph
+- May or may not contain machine-readable features
+- Uses standard security printing features
+
+**Examples of Strong evidence**:
+- US Federal or State driver's licence (Real ID compliant or standard)
+- US State identification card
+- US Military ID card (DD Form 2 — active duty or retired)
+- US Uniformed Services Privilege and Identification Card
+- Employment authorisation document (Form I-766)
+- Tribal identification card (government-issued)
+
+### Fair Evidence
+
+Evidence is designated Fair if it:
+- Is issued by a government agency or a regulated entity
+- Contains biographical attributes
+- Does not necessarily contain a photograph
+
+**Examples of Fair evidence**:
+- Voter registration card
+- US bank or financial institution account statement (less than 3 months old)
+- Utility bill with name and address (less than 3 months old)
+- Government-issued professional licence or certificate
+- Mortgage or lease agreement (regulated entity)
+- Social Security card (without photograph; used as Fair supporting document only)
+
+### Evidence Combinations Required by IAL
+
+| IAL | Minimum Evidence Combination |
+|-----|----------------------------|
+| IAL1 | No evidence required |
+| IAL2 | 1 piece of Superior evidence; OR 1 piece of Strong evidence + 2 pieces of Fair evidence |
+| IAL3 | 1 piece of Superior evidence AND a biometric comparison against the photo on that evidence using an authoritative database; OR 2 pieces of Strong evidence AND a biometric comparison |
+
+---
+
+## Evidence Validation
+
+After collecting evidence, the CSP must validate its authenticity.
+
+### Validation Methods
+
+| Method | Description |
+|--------|-------------|
+| **Automated validation** | Machine-readable zone (MRZ) parsed and verified; chip data (e.g., ICAO 9303 NFC) read and verified; barcode on document read and compared to visual data |
+| **Visual/physical inspection** | Trained operator examines security features: holograms, colour-shifting inks, raised printing, microprint, UV fluorescence |
+| **Database lookup** | Check document data against issuing authority database: AAMVA (driver's licences), USPS (addresses), Social Security Administration (SSN verification) |
+| **Third-party service** | Commercial KYC/identity document verification services (only when the service can demonstrate authoritative source access) |
+
+### Required Validation at IAL2
+
+- Check that the document is unexpired
+- Validate that the data on the document is consistent (MRZ matches VIZ data)
+- Verify against at least one authoritative source (e.g., AAMVA for driver's licences)
+- Confirm no indicators of tampering or forgery
+
+### Required Validation at IAL3
+
+- All IAL2 requirements, plus:
+- Physical inspection of security features by a trained representative
+- Automated chip verification (for chipped documents)
+- Comparison of photograph against biometric captured at time of proofing
+
+---
+
+## Identity Verification (Binding to the Real Person)
+
+After validating evidence, the CSP must verify that the person presenting the evidence is the same person described in it.
+
+### Verification at IAL2
+
+**In-person:**
+- A trained operator visually confirms the person matches the photograph on the evidence
+- The operator confirms liveness (the person is physically present)
+
+**Supervised remote (via video):**
+- A trained operator on a live video link confirms the person matches the photograph on evidence shown to the camera
+- Liveness checks (following the person's movements, asking them to show multiple angles) performed
+- Document is verified in real-time via automated scanning if possible
+
+**Biometric comparison (optional at IAL2):**
+- Facial image captured and compared against authoritative source (passport photo, DMV photo) via verified biometric matching algorithm
+- If biometric match fails, the proofing session must be terminated
+
+### Verification at IAL3
+
+- In-person only with a trained, authorised operator
+- Physical presence confirmed
+- Biometric comparison required (fingerprint or facial image) against an authoritative biometric database
+- CSP operator records the proofing event with date, operator ID, and outcome
+
+---
+
+## Address Confirmation
+
+After successful validation and verification, the CSP must confirm the applicant's address.
+
+### Purpose
+Ensures that the person who appeared for proofing also controls the physical address associated with the identity.
+
+### Methods
+
+| Method | Description | IAL Applicability |
+|--------|-------------|-------------------|
+| Enrollment code by postal mail | CSP sends a code to the validated address of record; applicant enters the code to complete enrollment | IAL2 (required if proofing done remotely and address not confirmed via authoritative source) |
+| USPS NCOA lookup | CSP queries USPS National Change of Address for the address associated with the identity; confirms address is current | IAL2 (supplemental) |
+| In-person address confirmation | Address is confirmed by the operator matching address on physical evidence to applicant's statement | IAL2 and IAL3 (in-person only) |
+
+**Enrollment code requirements (postal mail)**:
+- Minimum 6 characters, randomly generated
+- Valid window: up to 5 days after mailing
+- Single-use: invalidated after entry
+- Only one pending enrollment code at a time per applicant
+
+---
+
+## Knowledge-Based Verification (KBV) Limitations
+
+KBV (also called KBA — Knowledge-Based Authentication) uses questions derived from personal history or credit bureau records ("What was your first car?", "Which of the following streets have you lived on?").
+
+### SP 800-63A KBV Restrictions
+
+| Requirement | Detail |
+|------------|--------|
+| Standalone use | KBV alone is NOT sufficient for IAL2 — it may only supplement other proofing steps |
+| Static KBV | Prohibited at any IAL (static questions like "What is your mother's maiden name?" are deprecated) |
+| Dynamic KBV | Permitted only as supplementary step at IAL2; minimum 4 questions with at most 1 wrong answer permitted |
+| Waiting period after failure | If KBV fails: 2 weeks before retry; maximum 3 attempts total |
+| Application of KBV | Should only be used when in-person or supervised remote proofing is genuinely impractical; not a default substitution |
+
+---
+
+## Proofing and Privacy
+
+SP 800-63A requires CSPs to minimise PII collection:
+
+| Principle | Requirement |
+|-----------|------------|
+| Data minimisation | Collect only the attributes necessary to complete proofing and bind the identity; do not retain evidence images beyond what is necessary |
+| Notice | Inform applicants what data is collected, why, how it is stored, and who it is shared with |
+| Use limitation | PII collected during proofing must not be used for any purpose other than identity proofing, authentication, and authorisation |
+| Retention limits | Evidence images: CSP should determine minimum necessary retention period; raw biometrics: retain only as long as enrollment binding requires |
+| Third-party sharing | CSP must not share PII collected during proofing with other agencies or commercial entities unless required by law, and without subscriber consent |
+
+---
+
+## Failed Identity Proofing
+
+If identity proofing fails:
+
+| Scenario | Required Action |
+|---------|----------------|
+| Document verification fails (suspected forgery) | Terminate session; do not inform the applicant of specific failure reason (to prevent social engineering); report to appropriate authority if fraud suspected |
+| Biometric comparison fails | Up to 3 attempts; if all fail, terminate session; offer alternative in-person proofing channel |
+| KBV fails | 2-week waiting period; maximum 3 total attempts |
+| Applicant withdraws | Terminate session; purge all PII collected during the session per retention policy |
+
+---
+
+## Special Proofing Scenarios
+
+### Remote Proofing for Mobile Applicants
+
+For supervised remote proofing via mobile device:
+- Document scanning may use the device camera; all scanned images must be transmitted only over TLS-protected channels
+- Liveness detection algorithm must be used or the live operator must assess liveness via video
+- The operator must be able to ask the applicant to perform physical tasks to confirm liveness (look left/right, hold document next to face)
+
+### Proofing Minors
+
+SP 800-63A does not provide specific minor-proofing requirements; agencies must comply with COPPA (Children's Online Privacy Protection Act) and any applicable state laws when proofing minors. In practice, many federal programmes require the legal guardian to complete identity proofing on behalf of a minor.
+
+### Proofing for People Without Government-Issued ID
+
+Where an applicant cannot provide Superior or Strong evidence, CSPs may:
+- Accept a combination of authoritative documents sufficient to meet Fair evidence thresholds
+- Use IAL1 if the service can be delivered without identity proofing
+- Offer alternative access channels (in-person at a field office) if the agency can perform a different proofing exception process
+- Note: There is no "equivalency" exception in SP 800-63A; the evidence requirements are normative
+
+---
+
+## Notification of Proofing
+
+After successful proofing, the CSP must send a notification to the applicant at the verified address (postal or email, as appropriate):
+- Confirm that identity proofing was completed
+- Provide a means for the applicant to report if they did not initiate the proofing
+- Include a reference number for the enrollment event


### PR DESCRIPTION
## NIST SP 800-63 Rev 3 — Digital Identity Guidelines

**Source Publication**: NIST Special Publication 800-63 Rev 3, June 2017 (with errata March 2020)
**CSRC URL**: https://csrc.nist.gov/publications/detail/sp/800-63/3/final

This pull request adds a complete Claude skill plugin for NIST SP 800-63 Rev 3, the four-volume Digital Identity Guidelines suite. The skill supports identity architects, IAM engineers, federal agencies, and application developers in selecting assurance levels, implementing identity proofing, and choosing authenticators.

---

### Files Added

```
plugins/nist-sp-800-63/
  .claude-plugin/plugin.json
  skills/nist-sp-800-63/
    SKILL.md
    references/
      assurance-levels.md
      authenticator-requirements.md
      identity-proofing.md
```

---

### Framework Coverage

**IAL — Identity Assurance Level (SP 800-63A)**: IAL1 (no proofing), IAL2 (documentary evidence + supervised remote or in-person proofing), IAL3 (in-person with biometric binding). Full evidence type classification (Superior, Strong, Fair) with examples and required combination tables.

**AAL — Authenticator Assurance Level (SP 800-63B)**: All nine authenticator types documented with AAL eligibility, FIPS 140 requirements, and phishing resistance classification. AAL1 (single-factor), AAL2 (MFA with SMS RESTRICTED), AAL3 (hardware cryptographic MFA with verifier impersonation resistance). Deprecated practices documented (mandatory rotation, complexity rules, KBV, hints).

**FAL — Federation Assurance Level (SP 800-63C)**: FAL1 (signed bearer), FAL2 (signed and encrypted), FAL3 (holder-of-key with subscriber key binding). OIDC and SAML protocol examples per level.

**Digital Identity Risk Assessment**: SP 800-63-3 Section 6 risk assessment process for selecting xALs. Harm category taxonomy, impact level definitions, and xAL selection matrix by maximum impact level. Decoupled xAL selection guidance with example scenarios.

**Credential Lifecycle**: Authenticator binding, enrollment, adding new authenticators, account recovery (no KBV as sole mechanism). Reauthentication timeouts per AAL. PIV/CAC placement in the 800-63B framework.

---

### Reference Files

`references/assurance-levels.md` — Full IAL2/3 requirements in tabular format. AAL1/2/3 requirements with FIPS 140 levels, reauthentication timeouts, and phishing resistance. FAL1/2/3 requirements with protocol examples. xAL selection matrix and allowed xAL combinations. OMB M-19-17 supplemental requirements. PIV placement. Deprecated practices.

`references/authenticator-requirements.md` — Per-type requirements for all nine authenticator types. TOTP/HOTP algorithm requirements. SMS RESTRICTED compliance steps. FIPS 140 requirements per AAL. Verifier and CSP security requirements. Commonly used authenticator combinations by use case.

`references/identity-proofing.md` — Evidence type classification and required combinations. Validation methods (automated, visual, database). Verification methods for IAL2 and IAL3. Address confirmation and enrollment code requirements. KBV limitations and waiting periods. Privacy requirements. Failed proofing handling procedures.

---

### Integration Points

- SP 800-53 Rev 5 IA family: IA-2 (AAL requirements), IA-5 (authenticator management), IA-12 (identity proofing at IAL) reference 800-63 directly
- OMB M-19-17: AAL2 minimum for all federal applications; phishing-resistant auth for HVAs
- FIPS 201 PIV: PIV card is a Multi-Factor Cryptographic Device satisfying IAL2/3 + AAL3
- FedRAMP: Uses xAL selection to define authentication requirements in baselines

---

### Tests

```
python -m pytest tests/test_plugin_structure.py -v -k "nist-sp-800-63"

tests/test_plugin_structure.py::TestPluginDirectory::test_plugin_json_exists[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_plugin_json_is_valid[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_plugin_json_required_fields[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_plugin_version_semver[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_skills_directory_exists[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_skills_directory_has_one_skill_folder[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_skill_md_exists[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_skill_md_not_empty[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_no_files_outside_skill_folder[nist-sp-800-63] PASSED
tests/test_plugin_structure.py::TestPluginDirectory::test_references_are_markdown[nist-sp-800-63] PASSED

10 passed, 95 deselected in 0.07s
```